### PR TITLE
Forcing skip logic to top of loop

### DIFF
--- a/lib/swaggerfy.js
+++ b/lib/swaggerfy.js
@@ -83,12 +83,11 @@ var buildRouteMaps = function buildRouteMaps(opts, routes){
     Object.keys(routes).forEach(function (httpMethod) {
         routes[httpMethod].forEach(function (route) {
             trace("ROUTE: %j", route);
-            var routePath = route.spec.url || route.spec.path;
-            routePath = routePath.replace(/:(\w*)/g, "{$1}");
-
             if(shouldSkipRoute(opts, route)){
                 return;
             }
+            var routePath = route.spec.url || route.spec.path;
+            routePath = routePath.replace(/:(\w*)/g, "{$1}");
 
             var routeKey = routePath.split("/")[1];
             debug("routeKey = %s routePath = %s", routeKey, routePath);


### PR DESCRIPTION
This improves performance a minor amount and partially resolves an
issue around regex routePaths; a true and final mitigation may need to
either convert the routePath to String always [may behave unexpectedly]
or to have two paths through the code, one for String routePaths, and
one for regex routePaths.
