### PR TITLE
api role support

### DIFF
--- a/lib/swaggerfy.js
+++ b/lib/swaggerfy.js
@@ -34,7 +34,8 @@ var convertRouteToOperation = function convertRouteToOperation(route) {
         method: route.method,
         nickname: route.name,
         summary: route.spec.description || route.spec.summary,
-        responseMessages: route.spec.responseMessages
+        responseMessages: route.spec.responseMessages,
+        permittedRoles: route.permittedRoles || []
     };
 
     if(route.path.restifyParams){
@@ -60,7 +61,7 @@ var declareRoute = function declareRoute(route){
         route.spec.swagger.method = route.spec.swagger.method || route.method;
         route.spec.swagger.nickname = route.spec.swagger.nickname || route.name;
         route.spec.swagger.summary = route.spec.swagger.summary || (route.spec.description || route.spec.summary);
-
+        route.spec.swagger.permittedRoles = route.spec.swagger.permittedRoles || route.permittedRoles || [];
         return route.spec.swagger;
     }
 
@@ -120,6 +121,38 @@ var buildRouteMaps = function buildRouteMaps(opts, routes){
 
 };
 
+var filterApisByRoles = function filterApisByRoles(apis, roles){
+    var filteredApis = [];
+    if (!roles){
+        roles = [];
+    }
+    for (var apiIndex = 0; apiIndex < apis.length; apiIndex++){
+        var api = apis[apiIndex]
+            , isAnyOperationPermitted = false
+            , filteredApi = {operations: []};
+        for (var operationIndex = 0; operationIndex < api.operations.length; operationIndex++){
+            var operation = api.operations[operationIndex];
+            if (!operation.permittedRoles || operation.permittedRoles.length === 0){
+                isAnyOperationPermitted = true;
+                filteredApi.operations.push(operation);
+            }else{
+                for (var permittedRoleIndex = 0; permittedRoleIndex < operation.permittedRoles.length; permittedRoleIndex++){
+                    if (roles.indexOf(operation.permittedRoles[permittedRoleIndex]) >= 0){
+                        isAnyOperationPermitted = true;
+                        filteredApi.operations.push(operation);
+                        break;
+                    }
+                }
+            }
+        }
+        if (isAnyOperationPermitted){
+            filteredApi.path = api.path;
+            filteredApis.push(filteredApi);
+        }
+    }
+    return filteredApis;
+};
+
 var showApiDeclaration = function showApiDeclaration(opts, resourceName,  apiDeclaration){
     trace("spec = %j", apiDeclaration);
 
@@ -148,6 +181,7 @@ var showApiDeclaration = function showApiDeclaration(opts, resourceName,  apiDec
 
     return function(req, res, next){
         apiDetails.basePath = apiDetails.basePath || 'http://' + req.headers.host;
+        apiDetails.apis = filterApisByRoles(apiDetails.apis, req.apiRoles);
         res.send(apiDetails);
         return next();
     };


### PR DESCRIPTION
Hey Joe,
The general idea is that we want to get role-based filtering into swagger documentation. The idea here is that if the route configuration does not have permittedRoles [current situation] nothing changes. If it does, and permittedRoles is non-empty, filter which operations the requester can see based on req.apiRoles. In CNID, this will require a new [quick, easy] middleware to specify that based on oauth parameters [e.g.] which I'll be coding up; this is just what's needed on this end to make that happen happily.

Let me know if you have any comments!
