### PR TITLE
This adds support for people to add a sort priority for their endpoints. 

### DIFF
--- a/lib/swaggerfy.js
+++ b/lib/swaggerfy.js
@@ -181,19 +181,23 @@ var showApiDeclaration = function showApiDeclaration(opts, resourceName,  apiDec
         },
         originalApis
         ;
+    var anyPrioritySpecified = false;
     Object.keys(apiDeclaration).forEach(function(routePath){
         var operations = apiDeclaration[routePath];
         var priority = -1;
         for (var i = 0; i < operations.length; i++){
             if (operations[i].priority > priority){
+                anyPrioritySpecified = true;
                 priority = operations[i].priority;
             }
         }
         apiDetails.apis.push({path: routePath, operations: operations, priority: priority});
     });
-    apiDetails.apis.sort(function(a, b){
-        return b.priority - a.priority;
-    });
+    if (anyPrioritySpecified){
+        apiDetails.apis.sort(function(a, b){
+            return b.priority - a.priority;
+        });
+    }
     originalApis = apiDetails.apis;
 
     // TODO: Populate models with only models from this resource, instead of blindly adding all models.

--- a/lib/swaggerfy.js
+++ b/lib/swaggerfy.js
@@ -183,7 +183,16 @@ var showApiDeclaration = function showApiDeclaration(opts, resourceName,  apiDec
         ;
     Object.keys(apiDeclaration).forEach(function(routePath){
         var operations = apiDeclaration[routePath];
-        apiDetails.apis.push({path: routePath, operations: operations});
+        var priority = -1;
+        for (var i = 0; i < operations.length; i++){
+            if (operations[i].priority > priority){
+                priority = operations[i].priority;
+            }
+        }
+        apiDetails.apis.push({path: routePath, operations: operations, priority: priority});
+    });
+    apiDetails.apis.sort(function(a, b){
+        return b.priority - a.priority;
     });
     originalApis = apiDetails.apis;
 


### PR DESCRIPTION
Currently, it's somewhat arbitrary what order endpoints are listed in. Swagger-UI's sort functionality also leaves much to be desired in terms of its ability to be customized, but its default behavior is to use the ordering given by the server. Thus, sorting on the server achieves the goal.